### PR TITLE
fix: Radio button selection bug on sign-up page

### DIFF
--- a/src/components/SignUp/SignUp.jsx
+++ b/src/components/SignUp/SignUp.jsx
@@ -167,8 +167,8 @@ const SignUpForm = () => {
                 <input
                   type="radio"
                   class="student-option"
-                  name="student"
-                  value="1"
+                  name="occupation"
+                  value="student"
                   id=""
                 ></input>
               </span>
@@ -178,8 +178,8 @@ const SignUpForm = () => {
                 <input
                   type="radio"
                   class="counsellor-option"
-                  name="Counsellor"
-                  value="2"
+                  name="occupation"
+                  value="counsellor"
                   id=""
                 ></input>
               </span>


### PR DESCRIPTION
# Description

This PR addresses the issue  where multiple radio buttons could be selected simultaneously on the sign-up page. The fix ensures that only one option (either "Student" or "Counsellor") can be selected at a time by updating the radio buttons' name attribute. 

## Fixes #201 




## Checklist

- [X] Tests have been added or updated to cover the changes
- [X] Documentation has been updated to reflect the changes
- [X] Code follows the established coding style guidelines
- [X] All tests are passing