### PR TITLE
Disallow Future date as birth date on sign-up page #614

### DIFF
--- a/src/components/SignUp/SignUp.jsx
+++ b/src/components/SignUp/SignUp.jsx
@@ -327,6 +327,7 @@ const SignUpForm = () => {
                       type="date"
                       value={userInfo.dob}
                       name="dob"
+                      max={new Date().toJSON().slice(0, 10)}
                       onChange={handelUserInfo}
                       required
                     />


### PR DESCRIPTION
![date_pics](https://github.com/Counselllor/Counsellor-Web/assets/135598205/c1e2b23c-cb4f-4008-a6f1-b6bbcbbd094d)

Issue Solved #614 