### PR TITLE
Fixed content overlapping navbar issue 

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -25,7 +25,7 @@
   margin: 0px;
   background-color: white;
   font-weight: 500;
-  z-index: 10;
+  z-index: 99;
   max-height: 60px;
   /* border-radius: 5px; */
   font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;


### PR DESCRIPTION
# Description

The content on About page were overlapping navbar which is fixed now.

## Fixes #711 

Replace `issue_no` with the issue number which is fixed in this PR

## Screenshots

<!-- If applicable, add screenshots or images demonstrating the changes made -->

before:
![image](https://github.com/Counselllor/Counsellor-Web/assets/116087736/508b89a5-f891-4c80-98d3-aa1858207c6d)

after:
https://github.com/Counselllor/Counsellor-Web/assets/116087736/d42a9dad-165d-47d6-8081-23caa7e6205c


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x ] Tests have been added or updated to cover the changes
- [x ] Documentation has been updated to reflect the changes
- [x ] Code follows the established coding style guidelines
- [x ] All tests are passing