### PR TITLE
Social icons visible in light mode 

### DIFF
--- a/src/components/Footer/Footer.css
+++ b/src/components/Footer/Footer.css
@@ -64,6 +64,15 @@ footer li:hover{
     font-size: 20px;
     cursor: pointer;
     color: white;
+    transition: transform 0.4s ease;
+}
+
+#icons *:hover {
+    transform: scale(1.1);
+}
+
+#light footer #icons *{
+    color: #1C1C1C;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
# Description

The social icons are not visible in light mode 
Added special transition hover effect to the icons in light as well as dark mode 

## Fixes #766 

Replace `issue_no` with the issue number which is fixed in this PR

## Screenshots

![image](https://github.com/Counselllor/Counsellor-Web/assets/116087736/7416f043-c6c6-4e61-83b7-cbf1dd03464c)

![image](https://github.com/Counselllor/Counsellor-Web/assets/116087736/237d1015-33ba-4db2-8a9b-57d9024e2ee3)

![image](https://github.com/Counselllor/Counsellor-Web/assets/116087736/0fb7285e-6e57-475e-a4f7-6149928a56fa)

Hover:

[icons.webm](https://github.com/Counselllor/Counsellor-Web/assets/116087736/6e20dbf0-8cd1-4cf8-9e00-5a67b0a40f31)


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x ] Tests have been added or updated to cover the changes
- [x ] Documentation has been updated to reflect the changes
- [x ] Code follows the established coding style guidelines
- [x ] All tests are passing