### PR TITLE
Persist Dark Mode Setting Across Refreshes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,33 +4,39 @@ import "./styles/App.css";
 
 import Dashboard from './components/Dashboard/Dashboard';
 import CollegePage from './components/CollegePage/CollegePage';
-import { createContext, useState } from 'react';
+import { createContext, useState, useEffect } from 'react';
 
-
-//theme context
+// Theme context
 export const ThemeContext = createContext(null);
-//App
+
+// App
 const App = () => {
 
-  const [theme, setTheme] = useState("light");
+  // Get initial theme from localStorage or default to 'light'
+  const getInitialTheme = () => {
+    const savedTheme = localStorage.getItem("theme");
+    return savedTheme ? savedTheme : "light";
+  };
 
-  //Toggle theme
+  const [theme, setTheme] = useState(getInitialTheme);
+
+  // Toggle theme
   const toggleTheme = () => {
     setTheme((curr) => (curr === "light" ? "dark" : "light"));
-  }
+  };
+
+  // Save theme to localStorage whenever it changes
+  useEffect(() => {
+    localStorage.setItem("theme", theme);
+  }, [theme]);
 
   return (
     <ThemeContext.Provider value={{theme, toggleTheme}}>
-    <div className="App" id={theme}>
-      <Outlet />
-    </div>
+      <div className="App" id={theme}>
+        <Outlet />
+      </div>
     </ThemeContext.Provider>
   );
 };
 
-
-
 export default App;
-
-
-


### PR DESCRIPTION
# Description
Hey @thestarsahil 

I have fixed the issue regarding dark mode which was resetting after refreshing

**Changes I made are:**
-  Added a function `getInitialTheme` to retrieve the theme from `localStorage` or default to "light".
- Initialized the `useState` hook with the value returned by `getInitialTheme.`
-  Added a `useEffect` hook to save the current theme to localStorage whenever it changes.
-  Updated the `toggleTheme` function to toggle between `"light"` and `"dark"` themes.

## Fixes #867 

## Screenshots

https://github.com/Counselllor/Counsellor-Web/assets/163530398/818ec906-9d78-4e84-84ab-7b9104d86563



<!-- If applicable, add screenshots or images demonstrating the changes made -->

## Checklist

<!-- Mark the completed tasks with [x] -->
- [X] Tests have been added or updated to cover the changes
- [X] Documentation has been updated to reflect the changes
- [X] Code follows the established coding style guidelines
- [X] All tests are passing