### PR TITLE
Dark mode readability in 3 pages

### DIFF
--- a/src/components/Help/Help.css
+++ b/src/components/Help/Help.css
@@ -61,24 +61,11 @@ body {
 }
 
 #dark .help-container h2 {
-  color: #90b9f7 !important;
+  color: #9cbff5 !important;
 }
 
-#dark #getting-started p,ul,li , #contact-support p,ul,li , #account-management p,ul,li{
-  color: #d1e0f7 !important;
-}
- 
-#dark .contents p,
-ul,
-li {
-  color: #d1e0f7 !important;
-}
-
-
-#dark #faq p,
-ul,
-li {
-  color: #d1e0f7 !important;
+#dark .faq-question {
+  background-color: #333 !important;
 }
 
 .help-container p {
@@ -185,6 +172,3 @@ animation: animator1 forwards 0.6s;
   margin-right: 1rem;
 }
 
-#dark .faq-question{
-  background-color: #333 !important;
-}

--- a/src/components/Help/Help.css
+++ b/src/components/Help/Help.css
@@ -50,11 +50,35 @@ body {
   margin-bottom: 1rem;
   color: #3C38B9;
 }
+#dark .help-container h1 {
+  color: #7067ec !important;
+}
 
 .help-container h2 {
   color: #00073e;
   font-size: 30px;
   margin-top: 10px;
+}
+
+#dark .help-container h2 {
+  color: #90b9f7 !important;
+}
+
+#dark #getting-started p,ul,li , #contact-support p,ul,li , #account-management p,ul,li{
+  color: #d1e0f7 !important;
+}
+ 
+#dark .contents p,
+ul,
+li {
+  color: #d1e0f7 !important;
+}
+
+
+#dark #faq p,
+ul,
+li {
+  color: #d1e0f7 !important;
 }
 
 .help-container p {
@@ -118,10 +142,6 @@ animation: animator1 forwards 0.6s;
   color: #34495e;
   font-size: 30px;
   }
-  #dark .help-container h2 {
-    color: #1e83ef !important;
-    font-size: 30px;
-    }
 =======
 .faq-item {
   margin-bottom: 1rem;
@@ -165,3 +185,6 @@ animation: animator1 forwards 0.6s;
   margin-right: 1rem;
 }
 
+#dark .faq-question{
+  background-color: #333 !important;
+}

--- a/src/components/Privacy-Policy/Privacy.css
+++ b/src/components/Privacy-Policy/Privacy.css
@@ -170,6 +170,17 @@ color: #34495e;
 font-size: 30px;
 }
 #dark .privacy-policy-content h2 {
-  color: #1e83ef !important;
+  color: #7db4ee !important;
   font-size: 30px;
   }
+
+#dark .privacy-policy-content h1 {
+  color: #278af3 !important;
+}  
+#dark .privacy-policy-content .date span {
+  color: #e6e1e1 !important;
+}
+#dark .privacy-policy-content h3 {
+  color: #8fbef0 !important;
+  font-size: 30px;
+}

--- a/src/components/Terms/Terms.css
+++ b/src/components/Terms/Terms.css
@@ -19,7 +19,10 @@
   color: white ;
   } 
   #dark .terms-container h2{
-    color: #3b99ff;
+    color: #60a4ee !important;
+  }
+  #dark .terms-container h1{
+    color: #4491e4 !important;
   }
   .terms-container #cookies{
     margin-top: 50px;


### PR DESCRIPTION
# Description

In terms,privacy and help pages content wasnt readable in dark mode, I have fixed all that

## Fixes #882 

## Screenshots

![Screenshot 2024-07-08 013624](https://github.com/Counselllor/Counsellor-Web/assets/122633300/09d0c535-96ba-490e-8ce1-e0c8931d55ea)
![Screenshot 2024-07-08 013641](https://github.com/Counselllor/Counsellor-Web/assets/122633300/8747e7ea-f1aa-4d13-abac-64c37d89c0e8)
![Screenshot 2024-07-08 013659](https://github.com/Counselllor/Counsellor-Web/assets/122633300/7c23aa90-1b7b-4077-b25a-276caa5ce02a)


## Checklist

<!-- Mark the completed tasks with [x] -->
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated to reflect the changes
- [x] Code follows the established coding style guidelines
- [x] All tests are passing