### PR TITLE
Home link in the footer points to DashBoard 

### DIFF
--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -8,7 +8,7 @@ const Footer = () => {
       <div className="container">
         <div className="link-container">
           <ul className="link">
-            <li><a href="/">Home</a></li>
+            <li><a href="/dashboard">Home</a></li>
             <li><a href="./About">About Us</a></li>
             <li><a href="./blogs">Blog</a></li>
             <li><a href="./contribute">Our Contributors</a></li>


### PR DESCRIPTION
### Description

#### Issue
In the footer, clicking the "Home" link currently redirects to the login page. The expected behavior is for it to redirect to the dashboard page .

#### Changes Made
- Updated the "Home" link in the footer to redirect to the dashboard page instead of the login page.

#### Testing
- Verified that clicking the "Home" link in the footer now correctly redirects to the dashboard page .
