### PR TITLE
Fixed  After going to college student details and then click to profile it should open the User profile not student profile in the navbar and want to add image placeholder if no image available

### DIFF
--- a/src/components/Navbar/Navbar.jsx
+++ b/src/components/Navbar/Navbar.jsx
@@ -141,9 +141,10 @@ const MenuSection = ({ user, handleSignOut, menuOpen, toggleTheme, theme }) => (
             </a>
           </MenuItem>
           <MenuItem>
-            <a href="./profile">
-              <button className="profile_btn">Profile</button>
-            </a>
+<div>
+  
+             <button onClick={()=>window.location.href="/profile"} className="profile_btn">Profile</button>
+  </div>   
           </MenuItem>
         </>
       ) : (


### PR DESCRIPTION
# Description

I have fixed the issue now the user will redirect to the profile when clicking on the profile button 


## Fixes #1262 

Replace `issue_no` with the issue number which is fixed in this PR

## Screenshots


https://github.com/user-attachments/assets/191ffd25-6ba0-47ca-bc7a-5f15e7109902


## Checklist

<!-- Mark the completed tasks with [x] -->
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated to reflect the changes
- [ ] Code follows the established coding style guidelines
- [x] All tests are passing